### PR TITLE
Add timestamp and device to message log

### DIFF
--- a/ReadDeviceToCloudMessages/Program.cs
+++ b/ReadDeviceToCloudMessages/Program.cs
@@ -34,7 +34,8 @@ namespace ReadDeviceToCloudMessages
                 if (eventData == null) continue;
 
                 string data = Encoding.UTF8.GetString(eventData.GetBytes());
-                Console.WriteLine("Messages received: '{0}'", data); 
+                var message = $"{eventData.EnqueuedTimeUtc.ToLocalTime():hh:mm:ss.fff} {eventData.SystemProperties["iothub-connection-device-id"]} sent '{data}'";
+                Console.WriteLine(message);
             }
         }
 


### PR DESCRIPTION
To better support multiple devices connecting to the same hub:
<img alt="cmd_2016-06-04_15-33-18" src="https://cloud.githubusercontent.com/assets/133987/15801928/b6c38836-2a69-11e6-87b1-97398ca6d4cb.png">

/cc @BrianGenisio
